### PR TITLE
Custom BH Scans, Fix Null Hud

### DIFF
--- a/MTFO.Ext.Scans/CustomPuzzleData/ScanData.cs
+++ b/MTFO.Ext.Scans/CustomPuzzleData/ScanData.cs
@@ -6,6 +6,13 @@ namespace MTFO.Ext.Scans.CustomPuzzleData
     {
         public float FullTeamScanMulti { get; set; } = 0f;
         public float[][] PerTeamSizeScanMultis { get; set; } = Array.Empty<float[]>();
-        public uint PersistentID { get; set; } = 0;
+        public BioscanGFX BioScanGraphics { get; set; }
+        public uint PersistentID { get; set; } = 0u;
+    }
+
+    public struct BioscanGFX
+    {
+        public string ScanText { get; set; }
+        public bool HideBulkheadSkullGraphic { get; set; }
     }
 }

--- a/MTFO.Ext.Scans/EntryPoint.cs
+++ b/MTFO.Ext.Scans/EntryPoint.cs
@@ -6,7 +6,7 @@ using MTFO.Ext.Scans.Dependencies;
 
 namespace MTFO.Ext.Scans
 {
-    [BepInPlugin("MTFO.Extension.Scans", MODNAME, "1.0.2")]
+    [BepInPlugin("MTFO.Extension.Scans", MODNAME, "1.1.0")]
     [BepInDependency(MTFOWrapper.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     internal sealed class EntryPoint : BasePlugin
     {

--- a/MTFO.Ext.Scans/Patches/ScannerPatches.cs
+++ b/MTFO.Ext.Scans/Patches/ScannerPatches.cs
@@ -56,5 +56,29 @@ namespace MTFO.Ext.Scans.Patches
             scanMultis = null;
             return false;
         }
+
+        [HarmonyPatch(typeof(CP_Bioscan_Graphics), nameof(CP_Bioscan_Graphics.SetVisible))]
+        [HarmonyPostfix]
+        [HarmonyPriority(Priority.Low)]
+        private static void CustomBulkheadBioscanFix(CP_Bioscan_Graphics __instance, bool visible)
+        {
+            if (!visible || !ScanDataManager.TryGetScanData(__instance.gameObject, out var scanData)) return;
+
+            if (scanData.BioScanGraphics.HideBulkheadSkullGraphic)
+            {
+                __instance.SetText(scanData.BioScanGraphics.ScanText); // override BH scan text
+                foreach (var info in __instance.transform.FindChildrenRecursive("Skull", false))
+                {
+                    info?.gameObject.SetActive(false); // disable skull graphics
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(CP_Bioscan_Hud), nameof(CP_Bioscan_Hud.Setup))]
+        [HarmonyPrefix]
+        private static void NullBioscanHudTMPFix(CP_Bioscan_Hud __instance)
+        {
+            __instance.m_bioscanWorldText ??= new TMPro.TextMeshPro(); // fix null TMP on some bioscan huds
+        }
     }
 }


### PR DESCRIPTION
For Bulkhead Scans: 
- Added new field **"HideBulkheadSkullGraphic"**.
- Fixed MTFO ScanText not being applied to BH bioscans.

Other:
- Fixed an issue where some bioscans had a null `CP_Bioscan_Hud.m_bioscanWorldText`, which spammed the console.